### PR TITLE
Fix go mod repo to run only on current git project

### DIFF
--- a/lib/cmd-repo-mod.bash
+++ b/lib/cmd-repo-mod.bash
@@ -11,7 +11,7 @@ export GO111MODULE=on
 error_code=0
 # Assume parent folder of go.mod is module root folder
 #
-for sub in $(find . -name go.mod -not -path '*/vendor/*' -exec dirname "{}" ';' | sort -u); do
+for sub in $(git ls-files | grep '/go\.mod$' | grep -v "/vendor/" | xargs -n1 dirname | sort -u); do
 	pushd "${sub}" > /dev/null || exit 1
 	if [ "${error_on_output:-}" -eq 1 ]; then
 		output=$("${cmd[@]}" "${OPTIONS[@]}" 2>&1)


### PR DESCRIPTION
Use git ls-files to ignore submodules

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fluxninja/pre-commit-golang/1)
<!-- Reviewable:end -->
